### PR TITLE
CLIP-4: Use "insertHTML" instead of "insertText", as the latter is obscenely slow for text containing large numbers of newline characters.

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -3,7 +3,7 @@
     "manifest_version" : 2,
 
     "name"        : "Clipboard Permission Manager",
-    "version"     : "0.3",
+    "version"     : "0.4",
     "description" : "Allows users to grant direct clipboard access to web pages that use the W3C Clipboard API.",
 
     "icons" : {

--- a/chrome/public/execCommand.js
+++ b/chrome/public/execCommand.js
@@ -81,6 +81,23 @@
     };
 
     /**
+     * Escapes the given value such that it is interpreted as plain text when
+     * included within HTML.
+     *
+     * @param {String} text
+     *     The value to escape for inclusion within HTML.
+     *
+     * @returns {String}
+     *     The provided value, escaped such that it is interpreted as plain
+     *     text when included within HTML.
+     */
+    var escapeHTML = function escapeHTML(text) {
+        var div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    };
+
+    /**
      * Map of handlers for document.execCommand() functions, where the key of
      * each entry is the name of the command being overridden.
      *
@@ -93,7 +110,7 @@
          */
         'cut' : function handleCut() {
             setLocalClipboard(window.getSelection().toString());
-            _execCommand.call(this, 'insertText', false, '');
+            _execCommand.call(this, 'insertHTML', false, '');
         },
 
         /**
@@ -107,7 +124,8 @@
          * Handler for document.execCommand('paste').
          */
         'paste' : function handlePaste() {
-            _execCommand.call(this, 'insertText', false, clipboardContents);
+            _execCommand.call(this, 'insertHTML', false,
+                escapeHTML(clipboardContents));
         }
 
     };


### PR DESCRIPTION
See: https://glyptodon.org/jira/browse/CLIP-4

This change also bumps the version number to 0.4 in anticipation of releasing a new version.